### PR TITLE
Added clearpath_common as dep to install all the supported RMWs.

### DIFF
--- a/clearpath_viz/package.xml
+++ b/clearpath_viz/package.xml
@@ -11,6 +11,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>clearpath_common</exec_depend>
   <exec_depend>clearpath_description</exec_depend>
   <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>nav2_rviz_plugins</exec_depend>


### PR DESCRIPTION
Since `clearpath_viz` has no depends on any RWMs, they need to be installed.  `clearapth_common` installs all the supported RWMs.